### PR TITLE
Refine CMake build graph

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,134 +1,75 @@
-cmake_minimum_required(VERSION 3.22)
-project(pokework LANGUAGES C CXX)
+cmake_minimum_required(VERSION 3.24)
 
-# --- Global settings ---
+project(PokePort LANGUAGES C CXX)
+
+set(CMAKE_C_STANDARD 17)
+set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   set(CMAKE_BUILD_TYPE Debug CACHE STRING "Debug;Release;RelWithDebInfo;MinSizeRel" FORCE)
 endif()
 
-# --- Vulkan bootstrap (Windows-friendly & robust) ---
-
-# Try the standard module first
 find_package(Vulkan QUIET)
 
-# Help CMake with hints if needed
-if(NOT Vulkan_FOUND)
-  # If your SDK env var is set, add it to CMake's search paths
-  if(DEFINED ENV{VULKAN_SDK})
-    list(PREPEND CMAKE_PREFIX_PATH "$ENV{VULKAN_SDK}")
-  endif()
-  find_package(Vulkan QUIET)
-endif()
-
-# Manual fallback: build an imported target from the SDK layout
 if(NOT TARGET Vulkan::Vulkan)
-  # Try to infer the SDK root if the env var isn't set
   if(NOT DEFINED ENV{VULKAN_SDK} AND WIN32)
-    file(GLOB _vk_roots LIST_DIRECTORIES true "C:/VulkanSDK/*")
-    list(SORT _vk_roots DESCENDING)
-    foreach(_root IN LISTS _vk_roots)
-      if(EXISTS "${_root}/Include/vulkan/vulkan.h")
-        set(ENV{VULKAN_SDK} "${_root}")
+    file(GLOB _vulkan_sdks LIST_DIRECTORIES true "C:/VulkanSDK/*")
+    list(SORT _vulkan_sdks DESCENDING)
+    foreach(_sdk IN LISTS _vulkan_sdks)
+      if(EXISTS "${_sdk}/Include/vulkan/vulkan.h")
+        set(ENV{VULKAN_SDK} "${_sdk}")
         break()
       endif()
     endforeach()
   endif()
 
-  # Find header + lib manually
-  find_path(Vulkan_INCLUDE_DIR
-    NAMES vulkan/vulkan.h
-    HINTS "$ENV{VULKAN_SDK}/Include"
-  )
-  # Prefer 64-bit lib dir on Ninja x64 / MSVC x64
-  find_library(Vulkan_LIBRARY
-    NAMES vulkan-1
-    HINTS "$ENV{VULKAN_SDK}/Lib" "$ENV{VULKAN_SDK}/Lib32"
-  )
+  if(DEFINED ENV{VULKAN_SDK})
+    find_path(_vulkan_include_dir
+      NAMES vulkan/vulkan.h
+      HINTS "$ENV{VULKAN_SDK}/Include"
+    )
+    find_library(_vulkan_library
+      NAMES vulkan-1
+      HINTS "$ENV{VULKAN_SDK}/Lib64" "$ENV{VULKAN_SDK}/Lib" "$ENV{VULKAN_SDK}/Lib32"
+    )
+  endif()
 
-  if(Vulkan_INCLUDE_DIR AND Vulkan_LIBRARY)
+  if(_vulkan_include_dir AND _vulkan_library)
     add_library(Vulkan::Vulkan UNKNOWN IMPORTED)
     set_target_properties(Vulkan::Vulkan PROPERTIES
-      IMPORTED_LOCATION "${Vulkan_LIBRARY}"
-      INTERFACE_INCLUDE_DIRECTORIES "${Vulkan_INCLUDE_DIR}"
+      IMPORTED_LOCATION "${_vulkan_library}"
+      INTERFACE_INCLUDE_DIRECTORIES "${_vulkan_include_dir}"
     )
-    message(STATUS "Vulkan (manual): include=${Vulkan_INCLUDE_DIR}, lib=${Vulkan_LIBRARY}")
+    message(STATUS "Using Vulkan SDK from ${_vulkan_include_dir}")
   else()
-    message(FATAL_ERROR "Vulkan SDK not found.\n  - Ensure VULKAN_SDK is set (e.g., C:/VulkanSDK/1.4.321.1)\n  - Or install the Vulkan SDK / repair PATH.")
+    message(FATAL_ERROR
+      "Vulkan SDK not found.\n"
+      "  - Install the Vulkan SDK and ensure glslc is on PATH\n"
+      "  - Or set the VULKAN_SDK environment variable to the SDK root")
   endif()
 else()
-  # Optional: print what we found for sanity
   get_target_property(_vk_inc Vulkan::Vulkan INTERFACE_INCLUDE_DIRECTORIES)
-  message(STATUS "Vulkan found. Include dirs: ${_vk_inc}")
+  if(_vk_inc)
+    message(STATUS "Vulkan include directories: ${_vk_inc}")
+  endif()
 endif()
 
+option(BUILD_EMERALD_VIEWER "Build the emerald_viewer harness" ON)
+option(BUILD_FRAME_VIEWER "Build the frame_viewer sample application" ON)
 
-option(BUILD_APPS "Build host apps (frame_viewer)" ON)
-
-# NOTE: pokeemerald/ is present but not built by CMake (it has its own Makefile/devkitARM flow).
-# We'll integrate it later via a PC shim.
 add_subdirectory(hal)
 add_subdirectory(renderer)
-add_subdirectory(bridge) 
-add_subdirectory(extern)  
+add_subdirectory(bridge)
+add_subdirectory(extern)
 
-add_executable(emerald_viewer apps/emerald_viewer/main.cpp extern/host_pe/pe_host_config.h extern/host_pe/pe_probe.c "hal/gba_hw_redirect.h" "hal/gba_hw_redirect.cpp")
-target_include_directories(emerald_viewer PRIVATE ${CMAKE_SOURCE_DIR}/hal)
-target_link_libraries(emerald_viewer PRIVATE agb_vk agb_bridge gba_hal)
-
-target_link_libraries(agb_bridge PRIVATE gba_hal)         # bridge can see gba_port.h if needed later
-
-
-
-
-
-
-
-
-
-if(BUILD_APPS)
-  add_subdirectory(apps/frame_viewer)
+if(BUILD_EMERALD_VIEWER)
+  add_subdirectory(apps/emerald_viewer)
 endif()
 
-# Create the redirect layer library
-add_library(gba_hw_redirect STATIC
-    gba_hw_redirect.cpp
-)
-
-target_include_directories(gba_hw_redirect PUBLIC
-    ${CMAKE_CURRENT_SOURCE_DIR}
-)
-
-# Compile selected Pokemon Emerald files
-add_library(pokeemerald_gfx STATIC
-    # Start with core graphics files
-    pokeemerald/gflib/bg.c
-    pokeemerald/gflib/sprite.c
-    pokeemerald/gflib/window.c
-    pokeemerald/gflib/text.c
-    pokeemerald/gflib/gpu_regs.c
-    # Add more gradually
-)
-
-# Override Pokemon Emerald's headers with our redirects
-target_include_directories(pokeemerald_gfx PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}  # Gets our gba_hw_redirect.h FIRST
-    ${CMAKE_CURRENT_SOURCE_DIR}/pokeemerald/include
-    ${CMAKE_CURRENT_SOURCE_DIR}/pokeemerald/gflib
-)
-
-# Define flags to skip assembly and use PC build
-target_compile_definitions(pokeemerald_gfx PRIVATE
-    MODERN_COMPILER=1
-    NDEBUG=1
-)
-
-# Link everything
-target_link_libraries(PokePort PRIVATE
-    agb_vk
-    gba_hw_redirect
-    pokeemerald_gfx
-)
+if(BUILD_FRAME_VIEWER)
+  add_subdirectory(apps/frame_viewer)
+endif()

--- a/apps/emerald_viewer/CMakeLists.txt
+++ b/apps/emerald_viewer/CMakeLists.txt
@@ -1,38 +1,26 @@
-# apps/emerald_viewer/CMakeLists.txt
-cmake_minimum_required(VERSION 3.20)
-
-# Executable
 add_executable(emerald_viewer
-    main.cpp
+  main.cpp
 )
 
-# C++ standard (same as the rest of the tree)
 target_compile_features(emerald_viewer PRIVATE cxx_std_17)
 
-# Include dirs: HAL (gba_port.h), bridge (AgbHwState API), renderer public headers
 target_include_directories(emerald_viewer PRIVATE
-    ${CMAKE_SOURCE_DIR}/hal
-    ${CMAKE_SOURCE_DIR}/bridge
-    ${CMAKE_SOURCE_DIR}/renderer/src
+  ${CMAKE_SOURCE_DIR}/hal
+  ${CMAKE_SOURCE_DIR}/bridge
 )
 
-# Link against the split renderer + bridge
-target_link_libraries(emerald_viewer PRIVATE agb_vk agb_bridge)
-
-# If your renderer target didn't propagate Vulkan as PUBLIC, be explicit here.
-# Safe to keep even if not strictly required.
-find_package(Vulkan REQUIRED)
-target_link_libraries(emerald_viewer PRIVATE Vulkan::Vulkan)
-
-# Shader path define: identical contract used by agb_vk.cpp/readFile(SHADER_SPV_PATH)
-# This points to the SPIR-V produced under the renderer's binary dir.
-target_compile_definitions(emerald_viewer PRIVATE
-    SHADER_SPV_PATH=\"${CMAKE_BINARY_DIR}/renderer/compose_frame.comp.spv\"
+target_link_libraries(emerald_viewer
+  PRIVATE
+    agb_vk
+    agb_bridge
+    gba_hal
+    gba_hw_redirect
 )
 
-# Make sure the SPIR-V gets built before we run (only if that custom target exists).
-# Your build already shows a custom step "Compiling compose_frame.comp -> compose_frame.comp.spv",
-# so guard the dependency by name if it's available.
-if (TARGET compose_spv)
-    add_dependencies(emerald_viewer compose_spv)
+add_dependencies(emerald_viewer renderer_shaders)
+
+if(MSVC)
+  target_compile_options(emerald_viewer PRIVATE /W4 /permissive-)
+else()
+  target_compile_options(emerald_viewer PRIVATE -Wall -Wextra -Wpedantic)
 endif()

--- a/apps/frame_viewer/CMakeLists.txt
+++ b/apps/frame_viewer/CMakeLists.txt
@@ -1,37 +1,20 @@
-cmake_minimum_required(VERSION 3.22)
-
-# Prefer the canonical viewer main; fall back for transitional layouts
-set(_fv_candidates
-  ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp       # <= your repo currently has this
-  ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp
-  ${CMAKE_SOURCE_DIR}/renderer/src/main.cpp  # last resort while migrating
+add_executable(frame_viewer
+  main.cpp
 )
 
-set(FRAME_VIEWER_MAIN "")
-foreach(cand IN LISTS _fv_candidates)
-  if(EXISTS "${cand}")
-    set(FRAME_VIEWER_MAIN "${cand}")
-    message(STATUS "frame_viewer: using ${cand}")
-    break()
-  endif()
-endforeach()
+target_compile_features(frame_viewer PRIVATE cxx_std_17)
 
-if(FRAME_VIEWER_MAIN STREQUAL "")
-  message(FATAL_ERROR
-    "frame_viewer: Could not find main.cpp. Expected apps/frame_viewer/main.cpp (preferred),"
-    " or apps/frame_viewer/src/main.cpp, or renderer/src/main.cpp as a temporary fallback.")
-endif()
+target_link_libraries(frame_viewer
+  PRIVATE
+    agb_bridge
+    agb_vk
+    gba_hal
+)
 
-add_executable(frame_viewer ${FRAME_VIEWER_MAIN})
-
-# Build shader before running the viewer
 add_dependencies(frame_viewer renderer_shaders)
 
-# Link shim + renderer (renderer carries Vulkan & SHADER_SPV_PATH)
-target_link_libraries(frame_viewer PRIVATE agb_bridge agb_vk gba_hal)
-
 if(MSVC)
-  target_compile_options(frame_viewer PRIVATE /W4)
+  target_compile_options(frame_viewer PRIVATE /W4 /permissive-)
 else()
   target_compile_options(frame_viewer PRIVATE -Wall -Wextra -Wpedantic)
 endif()

--- a/bridge/CMakeLists.txt
+++ b/bridge/CMakeLists.txt
@@ -1,32 +1,25 @@
-﻿cmake_minimum_required(VERSION 3.22)
-
-# Collect bridge sources (adjust if you add more)
 set(BRIDGE_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/agb_bridge.cpp
 )
 
-foreach(f IN LISTS BRIDGE_SOURCES)
-  if(NOT EXISTS "${f}")
-    message(FATAL_ERROR "bridge: expected source not found: ${f}")
-  endif()
-endforeach()
-
 add_library(agb_bridge STATIC ${BRIDGE_SOURCES})
+
+target_compile_features(agb_bridge PRIVATE cxx_std_17)
 
 target_include_directories(agb_bridge
   PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_SOURCE_DIR}/renderer/src    # <- so bridge can include "agb_vk.h"
+    ${CMAKE_SOURCE_DIR}/renderer/src
 )
 
-# Optional: also link the renderer so dependents inherit SHADER_SPV_PATH & Vulkan
 target_link_libraries(agb_bridge
   PUBLIC
     agb_vk
+    gba_hal
 )
 
 if(MSVC)
-  target_compile_options(agb_bridge PRIVATE /W4)
+  target_compile_options(agb_bridge PRIVATE /W4 /permissive-)
 else()
   target_compile_options(agb_bridge PRIVATE -Wall -Wextra -Wpedantic)
 endif()

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -1,20 +1,24 @@
-# extern/CMakeLists.txt (or top-level where appropriate)
-add_library(pe_headers OBJECT
-  ${CMAKE_SOURCE_DIR}/extern/host_pe/pe_probe.c
-)
+set(PE_PROBE ${CMAKE_CURRENT_SOURCE_DIR}/host_pe/pe_probe.c)
 
-# Compile as C, bring in Emerald headers *only* here (not transitive)
-set_source_files_properties(${CMAKE_SOURCE_DIR}/extern/host_pe/pe_probe.c PROPERTIES LANGUAGE C)
-target_include_directories(pe_headers PRIVATE
-  ${CMAKE_SOURCE_DIR}/extern/pokeemerald/include
-  ${CMAKE_SOURCE_DIR}/extern/pokeemerald/include/constants
-)
+add_library(pe_headers OBJECT ${PE_PROBE})
+set_source_files_properties(${PE_PROBE} PROPERTIES LANGUAGE C)
 
-# Force-include our host config before any Emerald header, on MSVC and others
-if (MSVC)
-  target_compile_options(pe_headers PRIVATE /TC /FI ${CMAKE_SOURCE_DIR}/extern/host_pe/pe_host_config.h)
-else()
-  target_compile_options(pe_headers PRIVATE -std=c11 -include ${CMAKE_SOURCE_DIR}/extern/host_pe/pe_host_config.h)
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/pokeemerald/include)
+  target_include_directories(pe_headers PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/pokeemerald/include
+  )
 endif()
 
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/pokeemerald/include/constants)
+  target_include_directories(pe_headers PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/pokeemerald/include/constants
+  )
+endif()
 
+if(MSVC)
+  target_compile_options(pe_headers PRIVATE /TC "/FI${CMAKE_CURRENT_SOURCE_DIR}/host_pe/pe_host_config.h")
+else()
+  target_compile_options(pe_headers PRIVATE -std=gnu11 -include ${CMAKE_CURRENT_SOURCE_DIR}/host_pe/pe_host_config.h)
+endif()
+
+add_custom_target(pe_headers_build ALL DEPENDS pe_headers)

--- a/hal/CMakeLists.txt
+++ b/hal/CMakeLists.txt
@@ -1,2 +1,27 @@
 add_library(gba_hal INTERFACE)
-target_include_directories(gba_hal INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+
+target_include_directories(gba_hal INTERFACE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+)
+
+add_library(gba_hw_redirect STATIC
+  gba_hw_redirect.cpp
+)
+
+target_compile_features(gba_hw_redirect PRIVATE cxx_std_17)
+
+target_include_directories(gba_hw_redirect
+  PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+target_link_libraries(gba_hw_redirect
+  PUBLIC
+    gba_hal
+)
+
+if(MSVC)
+  target_compile_options(gba_hw_redirect PRIVATE /W4 /permissive-)
+else()
+  target_compile_options(gba_hw_redirect PRIVATE -Wall -Wextra -Wpedantic)
+endif()

--- a/renderer/CMakeLists.txt
+++ b/renderer/CMakeLists.txt
@@ -1,51 +1,34 @@
-cmake_minimum_required(VERSION 3.22)
+set(RENDERER_SHADER ${CMAKE_CURRENT_SOURCE_DIR}/shaders/compose_frame.comp)
+set(RENDERER_SHADER_SPV ${CMAKE_CURRENT_BINARY_DIR}/compose_frame.comp.spv)
 
-# Vulkan should already be found at the root; re-find is harmless
-find_package(Vulkan REQUIRED)
-
-# ---- Find glslc (Vulkan SDK) ----
 find_program(GLSLC glslc
   HINTS
     $ENV{VULKAN_SDK}/Bin
     $ENV{VULKAN_SDK}/bin
     $ENV{VULKAN_SDK}/Bin32
+    $ENV{VULKAN_SDK}/bin32
 )
-if(NOT GLSLC)
-  message(FATAL_ERROR "glslc not found. Install Vulkan SDK (set VULKAN_SDK) or add glslc to PATH.")
-endif()
 
-# ---- Shader compile rule ----
-set(SHADER_SRC ${CMAKE_CURRENT_SOURCE_DIR}/shaders/compose_frame.comp)
-set(SHADER_SPV ${CMAKE_CURRENT_BINARY_DIR}/compose_frame.comp.spv)
+if(NOT GLSLC)
+  message(FATAL_ERROR "glslc not found. Install the Vulkan SDK or add glslc to PATH.")
+endif()
 
 add_custom_command(
-  OUTPUT  ${SHADER_SPV}
-  COMMAND ${GLSLC} -o ${SHADER_SPV} ${SHADER_SRC}
-  DEPENDS ${SHADER_SRC}
-  COMMENT "Compiling compose_frame.comp -> compose_frame.comp.spv"
+  OUTPUT ${RENDERER_SHADER_SPV}
+  COMMAND ${GLSLC} --target-env=vulkan1.1 -o ${RENDERER_SHADER_SPV} ${RENDERER_SHADER}
+  DEPENDS ${RENDERER_SHADER}
+  COMMENT "Compiling compose_frame.comp → compose_frame.comp.spv"
   VERBATIM
 )
-add_custom_target(renderer_shaders DEPENDS ${SHADER_SPV})
+add_custom_target(renderer_shaders DEPENDS ${RENDERER_SHADER_SPV})
 
-# Forward-slash the path so MSVC string literal is clean
-set(SHADER_SPV_ESCAPED ${SHADER_SPV})
-if(WIN32)
-  string(REPLACE "\\" "/" SHADER_SPV_ESCAPED "${SHADER_SPV_ESCAPED}")
-endif()
-
-# ---- Renderer library (STATIC, deterministic) ----
 set(AGBVK_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/src/agb_vk.cpp
 )
 
-# Optional guard to help diagnose path issues
-foreach(f IN LISTS AGBVK_SOURCES)
-  if(NOT EXISTS "${f}")
-    message(FATAL_ERROR "renderer: expected source not found: ${f}")
-  endif()
-endforeach()
-
 add_library(agb_vk STATIC ${AGBVK_SOURCES})
+
+target_compile_features(agb_vk PRIVATE cxx_std_17)
 
 target_include_directories(agb_vk
   PUBLIC
@@ -57,22 +40,16 @@ target_link_libraries(agb_vk
     Vulkan::Vulkan
 )
 
-# Define the shader path for the library itself (so agb_vk.cpp sees it)
+file(TO_CMAKE_PATH "${RENDERER_SHADER_SPV}" RENDERER_SHADER_SPV_ESCAPED)
 target_compile_definitions(agb_vk
   PUBLIC
-    SHADER_SPV_PATH="${SHADER_SPV_ESCAPED}"
+    SHADER_SPV_PATH="${RENDERER_SHADER_SPV_ESCAPED}"
 )
 
-# Make sure the SPIR-V exists before anything uses the lib
 add_dependencies(agb_vk renderer_shaders)
 
-# Warnings
 if(MSVC)
   target_compile_options(agb_vk PRIVATE /W4 /permissive-)
 else()
   target_compile_options(agb_vk PRIVATE -Wall -Wextra -Wpedantic)
 endif()
-
-# Debug print
-get_target_property(_vk_inc Vulkan::Vulkan INTERFACE_INCLUDE_DIRECTORIES)
-message(STATUS "Vulkan include dirs: ${_vk_inc}")


### PR DESCRIPTION
## Summary
- modernize the top-level build to detect Vulkan once, expose build options, and stage subdirectories cleanly
- add a reusable gba_hw_redirect library and simplify each app’s build script with consistent dependencies
- streamline renderer, bridge, and extern configuration while ensuring shader compilation and header probes stay wired

## Testing
- cmake -S . -B build *(fails: Vulkan SDK not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d369f63ae483338255c802f2bbe4e9